### PR TITLE
(PE-15661) Add a TK status check

### DIFF
--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -24,4 +24,9 @@
     5) Returns the subject.
 
     If 1, 2 or 4 fail, a slingshot exception describing the failure is
-    thrown."))
+    thrown.")
+  (status [this level]
+    "Returns the TK status map at the supplied `level`. The `state`
+    key has the most interesting information. Callers should not rely
+    on the contents of `:status`, which contains the details used to
+    compute the `:state` value."))

--- a/test/puppetlabs/rbac_client/services/test_rbac.clj
+++ b/test/puppetlabs/rbac_client/services/test_rbac.clj
@@ -3,7 +3,7 @@
             [puppetlabs.http.client.sync :refer [create-client]]
             [puppetlabs.kitchensink.json :as json]
             [puppetlabs.rbac-client.protocols.rbac :as rbac]
-            [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service]]
+            [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service api-url->status-url]]
             [puppetlabs.rbac-client.testutils.config :as cfg]
             [puppetlabs.rbac-client.testutils.http :as http]
             [puppetlabs.trapperkeeper.app :as tk-app]
@@ -62,3 +62,68 @@
 
       (with-test-webserver-and-config handler _ (:server configs)
         (is (= rand-subject (rbac/valid-token->subject consumer-svc "token")))))))
+
+(deftest test-status-url
+  (are [service-url rbac-api-url] (= service-url (api-url->status-url rbac-api-url))
+    "https://foo.com:4444/status/v1/services"
+    "https://foo.com:4444/rbac/rbac-api"
+
+    "http://foo.com:4444/status/v1/services"
+    "http://foo.com:4444/rbac/rbac-api"
+
+    "https://foo.com/status/v1/services"
+    "https://foo.com/rbac/rbac-api"
+
+    "http://foo.com/status/v1/services"
+    "http://foo.com/rbac/rbac-api"))
+
+(deftest test-status-check
+  (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
+    (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)
+          status-results {:activity-service
+                          {:service_version "0.5.3",
+                           :service_status_version 1,
+                           :detail_level "info",
+                           :state "running",
+                           :status {:db_up true}}
+
+                          :rbac-service
+                          {:service_version "1.2.12",
+                           :service_status_version 1,
+                           :detail_level "info",
+                           :state "running",
+                           :status {:db_up true,
+                                    :activity_up true}}}
+
+          failed-response (http/malformed-json-400-resp "No 'level' parameter found in request")
+          handler (wrap-test-handler-middleware
+                   (fn [req]
+                     (if (= "critical" (get-in req [:params "level"]))
+                       (http/json-200-resp status-results)
+                       failed-response)))
+          error-handler (wrap-test-handler-middleware
+                         (fn [req]
+                           (if (= "critical" (get-in req [:params "level"]))
+                             (http/json-200-resp
+                              (-> status-results
+                                  (assoc-in [:rbac-service :state] "error")
+                                  (assoc-in [:rbac-service :status :db_up] false)))
+                             failed-response)))]
+
+      (with-test-webserver-and-config handler _ (:server configs)
+        (is (= {:service_version "1.2.12",
+                :service_status_version 1,
+                :detail_level "info",
+                :state "running",
+                :status {:db_up true,
+                         :activity_up true}}
+               (rbac/status consumer-svc "critical"))))
+
+      (with-test-webserver-and-config error-handler _ (:server configs)
+        (is (= {:service_version "1.2.12",
+                :service_status_version 1,
+                :detail_level "info",
+                :state "error",
+                :status {:db_up false,
+                         :activity_up true}}
+               (rbac/status consumer-svc "critical")))))))

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -13,7 +13,14 @@
                       (throw+ {:kind :puppetlabs.rbac/invalid-token
                                :msg (format "Token: %s" jwt-str)})
                       {:login "test_user"
-                       :id (str->uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec")}))))
+                       :id (str->uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec")}))
+                  (status [this level]
+                    {:service_version "1.2.12",
+                     :service_status_version 1,
+                     :detail_level "info",
+                     :state "running",
+                     :status {:db_up true,
+                              :activity_up true}})))
 
 (defservice dummy-rbac-service
   RbacConsumerService
@@ -26,4 +33,11 @@
       (throw+ {:kind :puppetlabs.rbac/invalid-token
                :msg (format "Token: %s" jwt-str)})
       {:login "test_user"
-       :id (str->uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec")})))
+       :id (str->uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec")}))
+  (status [this level]
+          {:service_version "1.2.12",
+           :service_status_version 1,
+           :detail_level "info",
+           :state "running",
+           :status {:db_up true,
+                    :activity_up true}}))


### PR DESCRIPTION
This commit adds a new function call that gets the status from the
configured RBAC service backend. Components who's services rely upon the
RBAC service being up to consider themselves up can use this new
function in the construction of their own status and status details map.
