### PR TITLE
(MAINT) make malformed-json-400-resp public

### DIFF
--- a/test/puppetlabs/rbac_client/testutils/http.clj
+++ b/test/puppetlabs/rbac_client/testutils/http.clj
@@ -19,7 +19,7 @@
             :msg (str "Request has a body but the 'Content-Type' header does"
                       " not include 'application/json")})})
 
-(defn- malformed-json-400-resp
+(defn malformed-json-400-resp
   [parse-error]
   {:status 400
    :headers {"Content-Type" "application/json"}


### PR DESCRIPTION
It's a test utility that is now being used to return a failed response
in the test-rbac code when a level parameter is not provided.
