### PR TITLE
(MAINT) Convert status state string to kwd

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -98,5 +98,6 @@
 
   (status [this level]
           (let [client (:status-client (service-context this))]
-            (-> (client :get "/" {:query-params {"level" level}})
-                (get-in [:body :rbac-service])))))
+            (-> (client :get "" {:query-params {"level" (name level)}})
+                (get-in [:body :rbac-service])
+                (update :state keyword)))))

--- a/test/puppetlabs/rbac_client/services/test_rbac.clj
+++ b/test/puppetlabs/rbac_client/services/test_rbac.clj
@@ -114,7 +114,7 @@
         (is (= {:service_version "1.2.12",
                 :service_status_version 1,
                 :detail_level "info",
-                :state "running",
+                :state :running,
                 :status {:db_up true,
                          :activity_up true}}
                (rbac/status consumer-svc "critical"))))
@@ -123,7 +123,7 @@
         (is (= {:service_version "1.2.12",
                 :service_status_version 1,
                 :detail_level "info",
-                :state "error",
+                :state :error,
                 :status {:db_up false,
                          :activity_up true}}
                (rbac/status consumer-svc "critical")))))))

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -18,7 +18,7 @@
                     {:service_version "1.2.12",
                      :service_status_version 1,
                      :detail_level "info",
-                     :state "running",
+                     :state :running,
                      :status {:db_up true,
                               :activity_up true}})))
 
@@ -38,6 +38,6 @@
           {:service_version "1.2.12",
            :service_status_version 1,
            :detail_level "info",
-           :state "running",
+           :state :running,
            :status {:db_up true,
                     :activity_up true}}))


### PR DESCRIPTION
TK status requires the state value in map to be a keyword like
`:running`. When this is serialized to JSON and sent over the wire (like
would happen with a status function call) that string needs to be
converted back into a keyword. This ensures local callers (i.e. users of
the RbacConsumerService in `pe-rbac-service`) and remote
callers (i.e. users of this library) will get consistent results.
