### PR TITLE
(PE-15817) Don't pass a nil rbac-url to be parsed for the status-url

### DIFF
--- a/test/puppetlabs/rbac_client/services/test_rbac.clj
+++ b/test/puppetlabs/rbac_client/services/test_rbac.clj
@@ -77,6 +77,16 @@
     "http://foo.com/status/v1/services"
     "http://foo.com/rbac/rbac-api"))
 
+(deftest test-status-check-without-config
+  (with-app-with-config tk-app [remote-rbac-consumer-service]
+    (assoc-in (:client configs) [:rbac-consumer :api-url] nil)
+    (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)
+          handler (wrap-test-handler-middleware
+                   (fn [req]
+                     (http/json-200-resp {:foo :bar})))]
+      (with-test-webserver-and-config handler _ (:server configs)
+        (is (= :unknown (rbac/status consumer-svc "critical")))))))
+
 (deftest test-status-check
   (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
     (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)


### PR DESCRIPTION
This commit prevents a `java.net.MalformedURLException: null` caused by not
passing an api-url in the rbac-consumer config that was caused by trying to
parse nil as a URL.
