### PR TITLE
(PDB-2853) Return state-map when rbac-url configuration is missing

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -117,4 +117,4 @@
                 (update :state keyword))
             (do
               (log/error "'rbac-consumer' not configured with an 'api-url'")
-              :unknown))))
+              {:state :unknown}))))

--- a/test/puppetlabs/rbac_client/services/test_rbac.clj
+++ b/test/puppetlabs/rbac_client/services/test_rbac.clj
@@ -85,7 +85,7 @@
                    (fn [req]
                      (http/json-200-resp {:foo :bar})))]
       (with-test-webserver-and-config handler _ (:server configs)
-        (is (= :unknown (rbac/status consumer-svc "critical")))))))
+        (is (= :unknown (:state (rbac/status consumer-svc "critical"))))))))
 
 (deftest test-status-check
   (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)


### PR DESCRIPTION
This commit returns `{:state :unknown}` instead of `:unknown` when the
rbac url is missing in the user configuration. Prior to this commit
consumers of the status function would call `:state` on the return value
and if the configuration was missing they would get `null` and add that
as the status of rbac which is not consistent with the tk-status api.
