### PR TITLE
(PE-16563) Add middleware for cert authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [ring/ring-core "1.4.0"]
                  [ring/ring-json  "0.3.1" :exclusions [clj-time]]
+                 [puppetlabs/ring-middleware "0.2.2" :exclusions [ring/ring-servlet hiccup]]
                  [slingshot "0.12.2"]
                  [puppetlabs/kitchensink ~ks-version :exclusions [joda-time clj-time]]
                  [puppetlabs/http-client "0.5.0"]
@@ -23,7 +24,8 @@
 
                  ;; these dependencies are only here to override transitive dependency version conflicts
                  [org.clojure/tools.reader "1.0.0-alpha1"]
-                 [commons-codec "1.9"]]
+                 [commons-codec "1.9"]
+                 [puppetlabs/ssl-utils "0.8.1"]]
   :pedantic? :abort
   :profiles {:test {:dependencies [[puppetlabs/kitchensink ~ks-version :classifier "test"]
                                    [puppetlabs/trapperkeeper ~tk-version :classifier "test" :exclusions [joda-time clj-time]]

--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -11,8 +11,12 @@
     responses.")
 
   (cert-whitelisted? [this ssl-client-cn]
-    "Given an ssh client CN string, returns whether or not that CN is on RBAC's
+    "Given an SSL client CN string, returns whether or not that CN is on RBAC's
     certificate whitelist.")
+
+  (cert->subject [this ssl-client-cn]
+     "Given an SSL client CN string, returns the subject associated with that
+     CN, or nil if no subject is associated.")
 
   (valid-token->subject [this jwt-str]
     "Given a JWT string, this function:

--- a/test/puppetlabs/rbac_client/middleware/test_authentication.clj
+++ b/test/puppetlabs/rbac_client/middleware/test_authentication.clj
@@ -1,10 +1,12 @@
 (ns puppetlabs.rbac-client.middleware.test-authentication
   (:require [clojure.test :refer [are deftest is testing]]
+            [cheshire.core :as json]
             [puppetlabs.rbac-client.middleware.authentication :as middleware]
             [puppetlabs.rbac-client.protocols.rbac :as rbac]
             [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service]]
             [puppetlabs.rbac-client.testutils.config :as cfg]
             [puppetlabs.rbac-client.testutils.http :as http]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.testutils.webserver :refer [with-test-webserver-and-config]])
@@ -17,34 +19,36 @@
     {:server server-cfg
      :client (cfg/rbac-client-config server-cfg)}))
 
-(def request-with-token
+(def test-request
   {:server-port (get-in configs [:server :ssl-port])
    :server-name (get-in configs [:server :ssl-host])
    :remote-addr "127.0.0.1"
    :uri "/secret-stuff"
    :scheme :https
    :request-method :get
-   :protocol "HTTP/1.1"
-   :headers {@#'puppetlabs.rbac-client.middleware.authentication/authn-header
-             "totes_legit"}})
+   :protocol "HTTP/1.1"})
 
-(deftest test-add-subject
-  (testing "when everything goes well, the subject map is added to the request object"
-    (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
-      (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)
-            rbac-handler (constantly (http/json-200-resp rand-subject))]
-        (with-test-webserver-and-config rbac-handler _ (:server configs)
-          (let [authd-handler (->> (fn [req] (is (= rand-subject (:subject req))))
-                                (middleware/wrap-token-only-access consumer-svc))]
-            (authd-handler request-with-token)))))))
+(def request-with-token
+  (assoc test-request :headers {@#'puppetlabs.rbac-client.middleware.authentication/authn-header
+                                "totes_legit"}))
 
-(deftest test-deny-unauthenticated-requests
-  (testing "the middleware blocks requests that"
-    (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
-      (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)]
+(def request-with-cert
+  (assoc test-request :ssl-client-cert "foo.example.com"))
+
+(deftest token-auth
+  (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
+    (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)]
+      (testing "when everything goes well, the subject map is added to the request object"
+        (let [rbac-handler (constantly (http/json-200-resp rand-subject))]
+          (with-test-webserver-and-config rbac-handler _ (:server configs)
+            (let [authd-handler (->> (fn [req] (is (= rand-subject (:subject req))))
+                                     (middleware/wrap-token-only-access consumer-svc))]
+              (authd-handler request-with-token)))))
+
+      (testing "the middleware blocks requests that"
         (testing "are missing a token"
           (let [authd-handler (->> (fn [req] (is (true? "middleware blocked request")))
-                                (middleware/wrap-token-only-access consumer-svc))
+                                   (middleware/wrap-token-only-access consumer-svc))
                 resp (authd-handler (assoc request-with-token :headers {}))]
             (is (= 401 (:status resp)))))
 
@@ -53,6 +57,30 @@
                                (http/json-resp 401 {:kind :puppetlabs.rbac/invalid-token}))]
             (with-test-webserver-and-config rbac-handler _ (:server configs)
               (let [authd-handler (->> (fn [req] (is (true? "middleware blocked request")))
-                                    (middleware/wrap-token-only-access consumer-svc))
+                                       (middleware/wrap-token-only-access consumer-svc))
                     resp (authd-handler request-with-token)]
                 (is (= 401 (:status resp)))))))))))
+
+(deftest token-and-cert-auth
+  (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
+    (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)]
+      (testing "when everything goes well, the subject map is added to the request object"
+        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted true :subject rand-subject})) ]
+          (with-test-webserver-and-config rbac-handler _ (:server configs)
+            (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
+              (let [authd-handler (->> (fn [req] (http/json-200-resp (:subject req)))
+                                       (middleware/wrap-token-and-cert-access consumer-svc))
+                    resp (authd-handler request-with-cert)]
+                (is (= 200 (:status resp)))
+                (is (= (update rand-subject :id str)
+                       (json/parse-string (:body resp) true))))))))
+      (testing "the middleware blocks requests that have a non-whitelisted cert"
+        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted false :subject nil}))]
+          (with-test-webserver-and-config rbac-handler _ (:server configs)
+            (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
+              (let [authd-handler (->> (fn [req] (is (true? "middleware blocked request")))
+                                       (middleware/wrap-token-and-cert-access consumer-svc))
+                    resp (authd-handler request-with-cert)]
+                (is (= 401 (:status resp)))))))))))
+
+

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -28,6 +28,9 @@
   (is-permitted? [this subject perm-str] true)
   (are-permitted? [this subject perm-strs] true)
   (cert-whitelisted? [this ssl-client-cn] true)
+  (cert->subject [this ssl-client-cn]
+    {:id #uuid "af94921f-bd76-4b58-b5ce-e17c029a2790"
+     :login "api_user"})
   (valid-token->subject [this jwt-str]
     (if (or (not jwt-str) (= "invalid-token" jwt-str))
       (throw+ {:kind :puppetlabs.rbac/invalid-token


### PR DESCRIPTION
This adds a wrap-token-and-cert-access middleware which applies both
token and cert-based authentication to a ring handler. The cert auth
assumes that the client certificate on a request has been validated by
the webserver and is thus trusted by the CA. It then uses a new
cert->subject protocol function to authenticate the user based on the
CN. The cert->subject function will return the subject associated with
the cert or nil if none is. If it returns a subject, that subject will
be attached to the request.

For now, the subject will always be the api_user if the cert is on the
whitelist and will otherwise by nil, but it's possible the future may
include other users associated with certs.
