### PR TITLE
(maint) update deps for tools.reader and puppetlabs/ring-middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,16 +14,16 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [ring/ring-core "1.4.0"]
-                 [ring/ring-json  "0.3.1" :exclusions [clj-time]]
-                 [puppetlabs/ring-middleware "0.2.2" :exclusions [ring/ring-servlet hiccup]]
+                 [ring/ring-core "1.4.0" :exclusions [clj-time]]
+                 [ring/ring-json  "0.4.0" :exclusions [clj-time cheshire]]
+                 [puppetlabs/ring-middleware "1.0.0" :exclusions [ring/ring-servlet hiccup]]
                  [slingshot "0.12.2"]
                  [puppetlabs/kitchensink ~ks-version :exclusions [joda-time clj-time]]
                  [puppetlabs/http-client "0.5.0"]
                  [puppetlabs/trapperkeeper ~tk-version :exclusions [joda-time clj-time]]
 
                  ;; these dependencies are only here to override transitive dependency version conflicts
-                 [org.clojure/tools.reader "1.0.0-alpha1"]
+                 [org.clojure/tools.reader "1.0.0-beta1"]
                  [commons-codec "1.9"]
                  [puppetlabs/ssl-utils "0.8.1"]]
   :pedantic? :abort


### PR DESCRIPTION
This brings the library into line with trapperkeeper-status and tk-ws-jetty9.
