### PR TITLE
(maint) change are-permitted? to always return a vector

### DIFF
--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -7,7 +7,7 @@
 
   (are-permitted? [this subject perm-strs]
     "Given an RbacSubject map and a list of permission strings of the form
-    \"object_type:action:instance\", returns a corresponding list of boolean
+    \"object_type:action:instance\", returns a corresponding vector of boolean
     responses.")
 
   (cert-whitelisted? [this ssl-client-cn]

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -6,7 +6,8 @@
 
 (def dummy-rbac (reify RbacConsumerService
                   (is-permitted? [this subject perm-str] true)
-                  (are-permitted? [this subject perm-strs] true)
+                  (are-permitted? [this subject perm-strs]
+                    (vec (repeat (count perm-strs) true)))
                   (cert-whitelisted? [this ssl-client-cn] true)
                   (valid-token->subject [this jwt-str]
                     (if (or (not jwt-str) (= "invalid-token" jwt-str))
@@ -26,7 +27,8 @@
   RbacConsumerService
   []
   (is-permitted? [this subject perm-str] true)
-  (are-permitted? [this subject perm-strs] true)
+  (are-permitted? [this subject perm-strs]
+                  (vec (repeat (count perm-strs) true)))
   (cert-whitelisted? [this ssl-client-cn] true)
   (cert->subject [this ssl-client-cn]
     {:id #uuid "af94921f-bd76-4b58-b5ce-e17c029a2790"


### PR DESCRIPTION
Presently the dummy version of are-permitted? returns the boolean true, and the real version returns false in the case of an improperly configured
rbac-consumer. This is a little dangerous because the method is documented as returning a list of booleans, and returning an actual boolean in
misconfiguration cases may lead to uncaught bugs (i.e (some true? (are-permitted? ...)) is not actually safe usage today).

I'm a little unsatisfied with returning [false] in the misconfiguration case --
it seems like that should probably just throw an exception for the caller to
deal with, but the same would apply to all the other methods in there and I'm
not sure who that would break. Interested in what the maintainers think.
