### PR TITLE
(PE-17562) Change the description of valid-token->subject and filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.4.1
+  * Change description of valid-token->subject to describe the new RBAC token implementation behavior
+  * filter the output of valid-token->subject to make sure behavior agrees with local consumer
 ### 0.4.0
   * Throw an exception in init of remote-rbac-consumer-service if rbac consumer has no api-url.
   * Ensure that are-permitted? always returns a vector.

--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -18,16 +18,14 @@
      "Given an SSL client CN string, returns the subject associated with that
      CN, or nil if no subject is associated.")
 
-  (valid-token->subject [this jwt-str]
-    "Given a JWT string, this function:
+  (valid-token->subject [this token-str]
+    "Given a token as a string, this function:
 
-    1) Checks validity of JWT using the pubkey specified in the rbac-cfg
-    2) Checks to see if token has expired
-    3) Converts the token into the subject it represents
-    4) Checks to see if the subject is revoked.
-    5) Returns the subject.
+    1) Checks the validity of the token with RBAC
+    2) Converts the token into the subject it represents
+    3) Returns the subject.
 
-    If 1, 2 or 4 fail, a slingshot exception describing the failure is
+    If 1, 2 fails, a slingshot exception describing the failure is
     thrown.")
   (status [this level]
     "Returns the TK status map at the supplied `level`. The `state`


### PR DESCRIPTION
With the change of RBAC tokens to random strings from jwts, the type
of validation and potential data that can be return changed.

This adds filtering to the valid-token->subject to only return the
subject data.  This makes the local version behave the same way
as the remote client.
