### PR TITLE
(maint) remove no-op

### DIFF
--- a/src/puppetlabs/rbac_client/core.clj
+++ b/src/puppetlabs/rbac_client/core.clj
@@ -31,7 +31,6 @@
          opts (-> opts
                   (dissoc :status-errors)
                   (#(merge {:as :text} %)))
-         pe-errors? (dissoc opts)
          url (str base-url path)
          response (try
                     (make-request client url method opts)


### PR DESCRIPTION
There is a pointless statement in the api-caller that this removes.
