### PR TITLE
(maint) clarify logic in json-api-caller

### DIFF
--- a/src/puppetlabs/rbac_client/core.clj
+++ b/src/puppetlabs/rbac_client/core.clj
@@ -47,20 +47,27 @@
                 :response (dissoc response :opts)}))
        response)))
 
+(defn- coerce-body-to-json
+  "given a request options map, if the map has a body entry,
+  specify json output headers and convert the body to stringified json"
+  [request]
+  (if (contains? request :body)
+    (-> request
+        (assoc-in [:headers "Content-Type"] "application/json")
+        (update-in [:body] json/generate-string))
+    request))
+
 (defn json-api-caller
   "Wraps api caller but will convert the body of the request/response to/from json.
   Adds approrpriate content type headers."
   ([client base-url method path] (json-api-caller client base-url method path {}))
   ([client base-url method path opts]
    (let [throw-body (:throw-body opts)
-         opts (cond-> opts
-                (not (contains? opts :headers)) (assoc :headers {})
-                true (assoc-in [:headers "Accept"] "application/json")
-                (contains? opts :body) (assoc-in [:headers "Content-Type"] "application/json")
-                (contains? opts :body) (update-in [:body] json/generate-string)
-                ;; We'll throw after parsing here.
-                 true (dissoc :throw-body)
-                (:throw-body opts) (assoc :status-errors false))
+         opts (-> opts
+                  (assoc-in [:headers "Accept"] "application/json")
+                  coerce-body-to-json
+                  (dissoc :throw-body)
+                  (update-in [:status-errors] #(if throw-body false %)))
          response (api-caller client base-url method path opts)
          parsed-body (try
                        (json/parse-string (:body response) true)


### PR DESCRIPTION
The logic used in json-api-caller was difficult to follow and contained
steps that were unnecessary.  This updates the flow in the function to
be more straightforward, and avoid the unnecessary steps.
