### PR TITLE
(PE-17669) update rbac client to use the v2 authentication endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.5.0
+  * Update valid-token->subject to query the v2 token/authenticate endpoint, to
+    enable updates to the last_active timestamp for timeout-based token
+    invalidation.
 ### 0.4.1
   * Change description of valid-token->subject to describe the new RBAC token implementation behavior
   * filter the output of valid-token->subject to make sure behavior agrees with local consumer

--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -110,8 +110,9 @@
 
   (valid-token->subject [this token-str]
                         (let [{:keys [rbac-client]} (service-context this)
-                              url (str "/v1/tokens/" token-str)]
-                          (-> (rbac-client :get url)
+                              payload {:token token-str
+                                       :update_last_activity? true}]
+                          (-> (rbac-client :post "/v2/token/authenticate" {:body payload})
                               :body
                               (parse-subject))))
 


### PR DESCRIPTION
Update rbac client to use the v2 authentication endpoint in order to
enable updatest to the last_active timestamp.