### PR TITLE
(maint) correct URL for token authentication

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -112,7 +112,7 @@
                         (let [{:keys [rbac-client]} (service-context this)
                               payload {:token token-str
                                        :update_last_activity? true}]
-                          (-> (rbac-client :post "/v2/token/authenticate" {:body payload})
+                          (-> (rbac-client :post "/v2/auth/token/authenticate" {:body payload})
                               :body
                               (parse-subject))))
 


### PR DESCRIPTION
Change the URL for token authentication from /token/authenticate to
/auth/token/authenticate so that it actually works.