### PR TITLE
(maint) make dependent on clj-parent 0.2.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,3 @@
-(def ks-version "1.3.0")
-(def tk-version "1.3.1")
-(def tk-jetty-version "1.5.0")
-(def i18n-version "0.4.3")
-
 (defn deploy-info
   [url]
   {:url url
@@ -14,28 +9,28 @@
   :description "Tools for interacting with PE RBAC"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [ring/ring-core "1.4.0" :exclusions [clj-time]]
-                 [ring/ring-json  "0.4.0" :exclusions [clj-time cheshire]]
-                 [puppetlabs/ring-middleware "1.0.0" :exclusions [ring/ring-servlet hiccup]]
-                 [slingshot "0.12.2"]
-                 [puppetlabs/kitchensink ~ks-version :exclusions [joda-time clj-time]]
-                 [puppetlabs/http-client "0.5.0"]
-                 [puppetlabs/trapperkeeper ~tk-version :exclusions [joda-time clj-time]]
 
-                 ;; these dependencies are only here to override transitive dependency version conflicts
-                 [org.clojure/tools.reader "1.0.0-beta1"]
-                 [commons-codec "1.9"]
-                 [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/i18n ~i18n-version]]
+  :parent-project {:coords [puppetlabs/clj-parent "0.2.4"]
+                   :inherit [:managed-dependencies]}
 
-  :plugins [[puppetlabs/i18n ~i18n-version]]
+  :dependencies [[org.clojure/clojure]
+                 [ring/ring-core]
+                 [ring/ring-json]
+                 [puppetlabs/ring-middleware]
+                 [slingshot]
+                 [puppetlabs/kitchensink]
+                 [puppetlabs/http-client]
+                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/i18n]]
+
   :pedantic? :abort
-  :profiles {:test {:dependencies [[puppetlabs/kitchensink ~ks-version :classifier "test"]
-                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test" :exclusions [joda-time clj-time]]
-                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :exclusions  [joda-time clj-time]]
-                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test" :exclusions  [joda-time clj-time]]]}
+  :profiles {:test {:dependencies [[puppetlabs/kitchensink :classifier "test"]
+                                   [puppetlabs/trapperkeeper :classifier "test"]
+                                   [puppetlabs/trapperkeeper-webserver-jetty9]
+                                   [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]]}
              :testutils {:source-paths ^:replace  ["test"]}}
+
+  :plugins [[lein-parent "0.3.1"]]
 
   :classifiers  [["test" :testutils]]
 


### PR DESCRIPTION
This changes the dependency structure to use clj-parent version 0.2.4