### PR TITLE
(PE-18632) convert group-ids to uuids

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -32,6 +32,12 @@
                :msg (str "Error parsing UUID " str-uuid)
                :kind ::invalid-uuid}))))
 
+(defn group-ids-str->uuids
+  [subject-map]
+  (if-let [group-ids (:group_ids subject-map)]
+    (assoc subject-map :group_ids (map str->uuid group-ids))
+    subject-map))
+
 (defn parse-subject
   [subject]
   (if subject
@@ -40,6 +46,7 @@
                       :last_login :role_ids :inherited_role_ids
                       :group_ids :is_superuser :is_revoked
                       :is_remote :is_group])
+        group-ids-str->uuids
         (update :id str->uuid))))
 
 (defn rbac-client

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -37,8 +37,10 @@
     (if (or (not jwt-str) (= "invalid-token" jwt-str))
       (throw+ {:kind :puppetlabs.rbac/invalid-token
                :msg (format "Token: %s" jwt-str)})
-      {:login "test_user"
-       :id (str->uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec")}))
+      {:login     "test_user"
+       :id        (str->uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec")
+       :group_ids ["aaaaaaaa-b53a-4ccd-9f4f-e93db6aa38ec"
+                   "bbbbbbbb-b53a-4ccd-9f4f-e93db6aa38ec"]}))
   (status [this level]
           {:service_version "1.2.12",
            :service_status_version 1,


### PR DESCRIPTION
The orchestrator, and code deployer are failing in 2016.5.x when used
with a user that has ldap-groups assigned due to a schema validation
error.

This updates the client check to convert the group ids to be
uuids if they are present.