### PR TITLE
(PE-18730) Update clj-http-client dependency to 0.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.2.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.2.5"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This version bump for the http client will automatically shepherd the
user-locale into the accept-language header of outgoing requests.