### PR TITLE
(PE-19300) Use clj-parent 0.4.2 for i18n dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.6.1
-  * Update i18n to 0.7.0 for pot file renaming
+  * Update to clj-parent 0.4.2 to pickup i18n 0.7.0 for pot file renaming
 
 ### 0.6.0
   * Allow tokens to be passed to `valid-token->subject` with `|no_keepalive` suffix to avoid

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.4.2"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -21,8 +21,7 @@
                  [puppetlabs/kitchensink]
                  [puppetlabs/http-client]
                  [puppetlabs/trapperkeeper]
-                 ;; remove version when moving to clj-parent 0.5+
-                 [puppetlabs/i18n "0.7.0"]]
+                 [puppetlabs/i18n]]
 
   :pedantic? :abort
   :profiles {:dev {:dependencies [[puppetlabs/kitchensink :classifier "test"]


### PR DESCRIPTION
clj-parent 0.4.2 includes i18n 0.7.0, so move to it to remove cleanup in
the future.