### PR TITLE
(PE-20265) reduce authentication logging verbosity

### DIFF
--- a/src/puppetlabs/rbac_client/middleware/authentication.clj
+++ b/src/puppetlabs/rbac_client/middleware/authentication.clj
@@ -64,8 +64,8 @@
       (if-let [token-str (token-from-request req)]
         (try+
           (let [subject (valid-token->subject rbac-svc token-str)]
-            (log/info (i18n/trs "Authenticated subject {0} ({1}) via authentication token"
-                                (:login subject) (:id subject)))
+            (log/debug (i18n/trs "Authenticated subject {0} ({1}) via authentication token"
+                                 (:login subject) (:id subject)))
             (handler (assoc req internal-subject-key subject)))
           (catch authn-error? e
             (build-response 401 e)))


### PR DESCRIPTION
Authentication successes were being logged at the info level.
For busy services, this fills the logs with useless information.

This change reduces the log level to debug to reduce the noise.