### PR TITLE
(maint) Properly split instances containing colons

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -17,7 +17,7 @@
   return a map that represents the permission.
   COPY-PASTE: https://github.com/puppetlabs/pe-rbac-service/blob/master/src/clj/puppetlabs/rbac/services/consumer.clj"
   [perm-str]
-  (let [[object-type action instance] (clojure.string/split perm-str #":")]
+  (let [[object-type action instance] (clojure.string/split perm-str #":" 3)]
     {:object_type object-type
      :action action
      :instance instance}))

--- a/test/puppetlabs/rbac_client/services/test_rbac.clj
+++ b/test/puppetlabs/rbac_client/services/test_rbac.clj
@@ -3,7 +3,7 @@
             [puppetlabs.http.client.sync :refer [create-client]]
             [puppetlabs.kitchensink.json :as json]
             [puppetlabs.rbac-client.protocols.rbac :as rbac]
-            [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service api-url->status-url]]
+            [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service api-url->status-url perm-str->map]]
             [puppetlabs.rbac-client.testutils.config :as cfg]
             [puppetlabs.rbac-client.testutils.http :as http]
             [puppetlabs.trapperkeeper.logging :refer [reset-logging]]
@@ -24,6 +24,25 @@
 (defn- wrap-test-handler-middleware
   [handler]
   (http/wrap-test-handler-middleware handler (:client configs)))
+
+(deftest test-perm-str->map
+  (testing "returns the correct value for a * permission"
+    (is (= {:object_type "environment"
+            :action "deploy_code"
+            :instance "production"}
+           (perm-str->map "environment:deploy_code:production"))))
+
+  (testing "returns the correct value for a simple permission"
+    (is (= {:object_type "console_page"
+           :action "view"
+           :instance "*" }
+           (perm-str->map "console_page:view:*"))))
+
+  (testing "returns the correct value for an instance containing colons"
+    (is (= {:object_type "tasks"
+            :action "run"
+            :instance "package::install" }
+         (perm-str->map "tasks:run:package::install")))))
 
 (deftest test-is-permitted?
   (testing "is-permitted? returns the first result from RBAC's API"


### PR DESCRIPTION
Previously, a permission like `tasks:run:package::install` would be split
into [tasks, run, package] with ::install dropped entirely, causing the
is-permitted? check to use the wrong instance. We now split the
permission into exactly three pieces, preserving colons within the
instance name.