### PR TITLE
(PE-23159) adds list-permitted interface to protocol and client

### DIFF
--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -15,8 +15,8 @@
     certificate whitelist.")
 
   (cert->subject [this ssl-client-cn]
-     "Given an SSL client CN string, returns the subject associated with that
-     CN, or nil if no subject is associated.")
+    "Given an SSL client CN string, returns the subject associated with that
+    CN, or nil if no subject is associated.")
 
   (valid-token->subject [this token-str]
     "Given a token as a string, this function:
@@ -27,8 +27,13 @@
 
     If 1, 2 fails, a slingshot exception describing the failure is
     thrown.")
+
   (status [this level]
     "Returns the TK status map at the supplied `level`. The `state`
     key has the most interesting information. Callers should not rely
     on the contents of `:status`, which contains the details used to
-    compute the `:state` value."))
+    compute the `:state` value.")
+
+  (list-permitted [this token object-type action]
+    "Returns the list of instances that correspond to the users permissions for
+    a given `object-type` and `action` pair. "))

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -20,7 +20,10 @@
                      :detail_level "info",
                      :state :running,
                      :status {:db_up true,
-                              :activity_up true}})))
+                              :activity_up true}})
+                  (list-permitted [this token object-type action]
+                    ["one", "two", "three"])))
+
 
 (defservice dummy-rbac-service
   RbacConsumerService
@@ -46,4 +49,6 @@
            :detail_level "info",
            :state :running,
            :status {:db_up true,
-                    :activity_up true}}))
+                    :activity_up true}})
+  (list-permitted [this token object-type action]
+                  ["one", "two", "three"]))


### PR DESCRIPTION
This adds a new function "list-permitted" that given a token,
an object type, and an action, returns the list of permissions
a user has access to.

The client is updated to include an uncertified client for
making this request as we want the authentication to be made through
the token that is provided, and not the ssl certificates.