### PR TITLE
(PE-24446): add list-permitted-for interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.8.2
+  * Implement interface for list-permitted-for method in RBAC
+
 ### 0.6.1
   * Update to clj-parent 0.4.2 to pickup i18n 0.7.0 for pot file renaming
 

--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -36,4 +36,8 @@
 
   (list-permitted [this token object-type action]
     "Returns the list of instances that correspond to the users permissions for
-    a given `object-type` and `action` pair. "))
+    a given `object-type` and `action` pair. ")
+    
+  (list-permitted-for [this subject object-type action]
+    "Returns the list of instances that correspond to the the user associated with
+    the provided subject, for the given `object_type` and `action` pair."))

--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -143,4 +143,10 @@
                   (let [{:keys [uncertified-rbac-client]} (service-context this)
                         headers {:headers {authn-header token}}]
                     (-> (uncertified-rbac-client :get (str "/v1/permitted/" object-type "/" action) headers)
+                        :body)))
+                        
+  (list-permitted-for [this subject object-type action]
+                      (let [{:keys [rbac-client]} (service-context this)
+                          user-id (str (:id subject))]
+                        (-> (rbac-client :get (str "/v1/permitted/" object-type "/" action "/" user-id))
                         :body))))

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -22,7 +22,9 @@
                      :status {:db_up true,
                               :activity_up true}})
                   (list-permitted [this token object-type action]
-                    ["one", "two", "three"])))
+                    ["one", "two", "three"])
+                  (list-permitted-for [this subject object-type action]
+                    ["four" "five" "six"])))
 
 
 (defservice dummy-rbac-service
@@ -51,4 +53,6 @@
            :status {:db_up true,
                     :activity_up true}})
   (list-permitted [this token object-type action]
-                  ["one", "two", "three"]))
+                  ["one", "two", "three"])
+  (list-permitted-for [this subject object-type action]
+                      ["four" "five" "six"]))


### PR DESCRIPTION
This commit implements the interface for the RBAC list-permitted-for method which requires a subject rather than token for determining the permitted instances for the given object type and action, as a way of determining permissions for the user contained in the given subject. 