### PR TITLE
(PE-24735) add subject interface to consumer protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.8.3
+  * Add to rbac client protocol the "subject" interface, that given a user
+  id, will return the subject that corresponds to that id.
+
 ### 0.8.2
   * Implement interface for list-permitted-for method in RBAC
 

--- a/src/puppetlabs/rbac_client/core.clj
+++ b/src/puppetlabs/rbac_client/core.clj
@@ -45,7 +45,7 @@
                           :body (:body response)}
                 :msg (i18n/tru "Error executing {0} to {1} Status: {2,number,#}" (name method) url (:status response))
                 :response (dissoc response :opts)}))
-       response)))
+     response)))
 
 (defn- coerce-body-to-json
   "given a request options map, if the map has a body entry,

--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -40,4 +40,7 @@
     
   (list-permitted-for [this subject object-type action]
     "Returns the list of instances that correspond to the the user associated with
-    the provided subject, for the given `object_type` and `action` pair."))
+    the provided subject, for the given `object_type` and `action` pair.")
+
+  (subject [this uuid]
+   "Given a UUID for a given user, return the full subject representation for the user"))

--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -147,6 +147,12 @@
                         
   (list-permitted-for [this subject object-type action]
                       (let [{:keys [rbac-client]} (service-context this)
-                          user-id (str (:id subject))]
+                            user-id (str (:id subject))]
                         (-> (rbac-client :get (str "/v1/permitted/" object-type "/" action "/" user-id))
-                        :body))))
+                            :body)))
+
+  (subject [this user-id]
+           (let [{:keys [rbac-client]} (service-context this)]
+             (-> (rbac-client :get (str "/v1/users/" user-id))
+                 :body
+                 parse-subject))))

--- a/test/puppetlabs/rbac_client/test_core.clj
+++ b/test/puppetlabs/rbac_client/test_core.clj
@@ -20,15 +20,15 @@
           app (constantly {:status 500 :body "server error"})
           port 38924]
       (with-test-webserver app port
-(is (= "server error" (:body (core/api-caller client (format "http://localhost:%s/" port) :get ""))))
+        (is (= "server error" (:body (core/api-caller client (format "http://localhost:%s/" port) :get ""))))
         (is (thrown+? [:kind :puppetlabs.rbac-client/status-error]
-               (:body (core/api-caller client (format "http://localhost:%s/" port) :get "" {:status-errors true}))))))
-(let [client (create-client {})
+                      (:body (core/api-caller client (format "http://localhost:%s/" port) :get "" {:status-errors true}))))))
+
+    (let [client (create-client {})
           app (constantly {:status 500 :body "ok"})
           port 38924]
-        (is (thrown+? [:kind :puppetlabs.rbac-client/connection-failure]
-               (:body (core/api-caller client (format "http://localhost:%s/" port) :get "")))))))
-
+      (is (thrown+? [:kind :puppetlabs.rbac-client/connection-failure]
+                    (:body (core/api-caller client (format "http://localhost:%s/" port) :get "")))))))
 
 (deftest test-json-api-caller
   (with-test-logging
@@ -53,4 +53,4 @@
         (is (thrown+? [:kind :invalid]
                       (core/json-api-caller client (format "http://localhost:%s/" port) :get "" {:throw-body true})))
         (is (thrown+? [:kind :puppetlabs.rbac-client/status-error]
-        (core/json-api-caller client (format "http://localhost:%s/" port) :get "" {:status-errors true})))))))
+                      (core/json-api-caller client (format "http://localhost:%s/" port) :get "" {:status-errors true})))))))

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -55,4 +55,7 @@
   (list-permitted [this token object-type action]
                   ["one", "two", "three"])
   (list-permitted-for [this subject object-type action]
-                      ["four" "five" "six"]))
+                      ["four" "five" "six"])
+  (subject [this user-id]
+           {:id user-id
+            :login "anImaginaryUserForTesting"}))


### PR DESCRIPTION
This adds a subject interface that given a user id, will return
the subject map for that user.  It adds an implementation to the
remote client and the dummy version as well.