### PR TITLE
(PE-25601) remove per-route limits for activity/rbac clients

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.5"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.15"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]

--- a/src/puppetlabs/rbac_client/services/activity.clj
+++ b/src/puppetlabs/rbac_client/services/activity.clj
@@ -13,7 +13,9 @@
   [[:ConfigService get-in-config]]
   (init [this context]
     (let [api-url (get-in-config [:activity-consumer :api-url])
-          client (create-client (get-in-config [:global :certs]))]
+          ssl-config (get-in-config [:global :certs])
+          route-limit {:max-connections-per-route 20}
+          client (create-client (merge route-limit ssl-config))]
       (assoc context :client client
              :activity-client (partial json-api-caller client api-url))))
 

--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -76,8 +76,9 @@
   (init [_ tk-ctx]
         (if-let [rbac-url (get-in-config [:rbac-consumer :api-url])]
           (let [ssl-config (get-in-config [:global :certs])
-                certified-client (create-client ssl-config)
-                uncertified-client (create-client (select-keys ssl-config [:ssl-ca-cert]))]
+                route-limit {:max-connections-per-route 20}
+                certified-client (create-client (merge route-limit ssl-config))
+                uncertified-client (create-client (merge route-limit (select-keys ssl-config [:ssl-ca-cert])))]
             (assoc tk-ctx
                    :client certified-client
                    :uncertified-client uncertified-client


### PR DESCRIPTION
This increases the per route (server + port) limits for the rbac
and activity clients to 20.  The default is 2, and thiere is no
good reason to not allow more.  It has a positive impact on
performance for the applications that use the increased limit.