### PR TITLE
(maint) Handle missing cert in cert-related functions

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -111,19 +111,21 @@
                         :body)))
 
   (cert-whitelisted? [this ssl-client-cn]
-                     (let [{:keys [rbac-client]} (service-context this)
-                           url (str "/v1/certs/" ssl-client-cn)]
-                       (-> (rbac-client :get url)
-                           :body
-                           :whitelisted)))
+                     (when ssl-client-cn
+                       (let [{:keys [rbac-client]} (service-context this)
+                             url (str "/v1/certs/" ssl-client-cn)]
+                         (-> (rbac-client :get url)
+                             :body
+                             :whitelisted))))
 
   (cert->subject [this ssl-client-cn]
-                 (let [{:keys [rbac-client]} (service-context this)
-                       url (str "/v1/certs/" ssl-client-cn)]
-                   (-> (rbac-client :get url)
-                       :body
-                       :subject
-                       (parse-subject))))
+                 (when ssl-client-cn
+                   (let [{:keys [rbac-client]} (service-context this)
+                         url (str "/v1/certs/" ssl-client-cn)]
+                     (-> (rbac-client :get url)
+                         :body
+                         :subject
+                         (parse-subject)))))
 
   (valid-token->subject [this token-str]
                         (let [{:keys [rbac-client]} (service-context this)
@@ -145,7 +147,7 @@
                         headers {:headers {authn-header token}}]
                     (-> (uncertified-rbac-client :get (str "/v1/permitted/" object-type "/" action) headers)
                         :body)))
-                        
+
   (list-permitted-for [this subject object-type action]
                       (let [{:keys [rbac-client]} (service-context this)
                             user-id (str (:id subject))]


### PR DESCRIPTION
Previously, the `cert-whitelisted?` and `cert->subject` functions would
generate an incorrect URL when called without a cert. This commit
updates them to return nil in that case, which matches the behavior of
the standard implementations in the RBAC service.

This case is important because the cert-based authentication middleware
in RBAC calls cert->subject regardless of whether a cert was actually
supplied, relying on the function to return nil when no cert is present.
This bug causes issues for services depending on the cert middleware
in cases where they're running with a remote RBAC service.