### PR TITLE
Add wrap-cert-only-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.9.4
+  * Add wrap-cert-only-access authentication middleware for endpoints that only accept
+    RBAC whitelisted SSL certs.
+
 ### 0.9.1
 ### 0.8.3
   * Add to rbac client protocol the "subject" interface, that given a user

--- a/src/puppetlabs/rbac_client/middleware/authentication.clj
+++ b/src/puppetlabs/rbac_client/middleware/authentication.clj
@@ -141,6 +141,16 @@
        wrap-block-anonymous-access
        (wrap-token-access* rbac-svc)))
 
+(defn wrap-cert-only-access
+  "This middleware should be applied to ring handlers that want to allow *only*
+  whitelisted SSL certs. It takes an RBAC Consumer Service and a ring handler
+  to wrap."
+  [rbac-svc handler]
+  (->> handler
+       wrap-block-anonymous-access
+       (wrap-cert-access* rbac-svc)
+       wrap-with-certificate-cn))
+
 (defn wrap-token-and-cert-access
   "A middleware that permits route access by both authentication tokens and
   whitelisted SSL certs. Takes an Rbac Consumer Service and a ring handler."


### PR DESCRIPTION
Add middleware for endpoints that are only accessible via RBAC's
whitelisted SSL certs.