### PR TITLE
(PE-29720) add support for activity service v2 POST endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: clojure
 lein: 2.8.1
 jdk:
-  - oraclejdk8
   - openjdk8
   - openjdk11
 script: ./ext/travisci/test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.0
+  * update to use clj-parent 2.6.0
+  * add support for activity v2 api and fall back to v1 if v2 isn't supported
+
 ### 0.9.4
   * Add wrap-cert-only-access authentication middleware for endpoints that only accept
     RBAC whitelisted SSL certs.

--- a/project.clj
+++ b/project.clj
@@ -5,12 +5,12 @@
    :password :env/clojars_jenkins_password
    :sign-releases false})
 
-(defproject puppetlabs/rbac-client "0.9.5-SNAPSHOT"
+(defproject puppetlabs/rbac-client "1.0.0-SNAPSHOT"
   :description "Tools for interacting with PE RBAC"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.3.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.6.0"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -29,7 +29,7 @@
                                   [puppetlabs/trapperkeeper-webserver-jetty9]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
                                   ; transitive dependency
-				  [org.clojure/tools.nrepl "0.2.13"]]}
+                                  [org.clojure/tools.nrepl "0.2.13"]]}
              :testutils {:source-paths ^:replace  ["test"]}}
 
   :plugins [[lein-parent "0.3.1"]

--- a/src/puppetlabs/rbac_client/services/activity.clj
+++ b/src/puppetlabs/rbac_client/services/activity.clj
@@ -1,11 +1,48 @@
 (ns puppetlabs.rbac-client.services.activity
   (:require
+   [clojure.tools.logging :as log]
    [puppetlabs.rbac-client.protocols.activity :refer [ActivityReportingService]]
    [puppetlabs.http.client.common :as http]
    [puppetlabs.http.client.sync :refer [create-client]]
    [puppetlabs.rbac-client.core :refer [json-api-caller]]
    [puppetlabs.trapperkeeper.core :refer [defservice]]
    [puppetlabs.trapperkeeper.services :refer [service-context]]))
+
+(defn v1->v2
+  ;; make any adjustments needed to make a (maybe) v1 payload into a v2 payload
+  [event-bundle]
+  (if (contains? event-bundle :object)
+    (-> event-bundle
+        (dissoc :object)
+        (assoc :objects [(:object event-bundle)]))
+    event-bundle))
+
+(defn v2->v1
+  ;; make any adjustments needed to make a (maybe) v2 payload into a v1 payload
+  [event-bundle]
+  (let [result (dissoc event-bundle :ip-address)]
+    (if (contains? event-bundle :objects)
+      (-> (dissoc result :objects)
+          (assoc :object (first (:objects event-bundle))))
+      result)))
+
+(defn report-activity
+  [context event-bundle]
+  (let [activity-client (:activity-client context)
+        supports-v2? (:supports-v2-api context)]
+    (if @supports-v2?
+      (let [v2-bundle (v1->v2 event-bundle)
+            result (activity-client :post "/v2/events" {:body v2-bundle})]
+        ;; if we get a 404, the activity service doesn't support the v2 endpoint, so
+        ;; cache that, and retry.
+        (if (= 404 (:status result))
+          (do
+            (log/info "Configured activity service does not support v2 API, falling back to v1")
+            (swap! supports-v2? (constantly false))
+            (report-activity context event-bundle))
+          result))
+      (let [v1-bundle (v2->v1 event-bundle)]
+       (activity-client :post "/v1/events" {:body v1-bundle})))))
 
 (defservice remote-activity-reporter
   "service to report to a remote activity service"
@@ -16,7 +53,9 @@
           ssl-config (get-in-config [:global :certs])
           route-limit {:max-connections-per-route 20}
           client (create-client (merge route-limit ssl-config))]
-      (assoc context :client client
+      (assoc context
+             :client client
+             :supports-v2-api (atom true)
              :activity-client (partial json-api-caller client api-url))))
 
   (stop [this context]
@@ -25,5 +64,5 @@
     context)
 
   (report-activity! [this event-bundle]
-    (let [activity-client (-> this service-context :activity-client)]
-      (activity-client :post "/v1/events" {:body event-bundle}))))
+    (let [context (service-context this)]
+      (report-activity context event-bundle))))

--- a/test/puppetlabs/rbac_client/services/test_activity.clj
+++ b/test/puppetlabs/rbac_client/services/test_activity.clj
@@ -1,6 +1,117 @@
 (ns puppetlabs.rbac-client.services.test-activity
-  (:require [clojure.test :refer [deftest testing is]]
-            [puppetlabs.rbac-client.services.activity :as activity]))
+  (:require [cheshire.core :as json]
+            [clojure.test :refer [deftest testing is]]
+            [puppetlabs.rbac-client.protocols.activity :as act]
+            [puppetlabs.rbac-client.services.activity :refer [remote-activity-reporter]]
+            [puppetlabs.rbac-client.testutils.config :as cfg]
+            [puppetlabs.rbac-client.testutils.http :as http]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
+            [puppetlabs.trapperkeeper.testutils.webserver :refer [with-test-webserver-and-config]]))
 
-(deftest test-remote-activity-reporter
-  (is true))
+(def ^:private configs
+  (let [server-cfg (cfg/jetty-ssl-config)]
+    {:server server-cfg
+     :client (cfg/rbac-client-config server-cfg)}))
+
+(defn- wrap-test-handler-middleware
+  [handler]
+  (http/wrap-test-handler-mw handler))
+
+(def v2-bundle
+  {:commit
+   {:service
+    {:id "namer"}}
+   :subject
+   {:name "Herman Melville"
+    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+   :objects
+   [{:name "Herman Aldrich"
+     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+     :type "a Herman"}
+    {:name "Herman Miller",
+     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac33",
+     :type "a Herman"}
+    {:name "Herman Stump",
+     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac34",
+     :type "a Herman"}
+    {:name "Herman W. Hellman",
+     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac35",
+     :type "a Herman"}]
+   :ip-address "an ip address"})
+
+(def v1-bundle
+  {:commit
+   {:service
+    {:id "namer"}}
+   :subject
+   {:name "Herman Melville"
+    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+   :object {:name "Herman Aldrich"
+            :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+            :type "a Herman"}})
+
+(def expected-v1-bundle
+  {:commit
+   {:service
+    {:id "namer"}}
+   :subject
+   {:name "Herman Melville"
+    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+   :object
+   {:name "Herman Aldrich"
+    :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+    :type "a Herman"}})
+
+(def expected-v1-upgraded-bundle
+  {:commit
+   {:service
+    {:id "namer"}}
+   :subject
+   {:name "Herman Melville"
+    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+   :objects [{:name "Herman Aldrich"
+              :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+              :type "a Herman"}]})
+
+
+(deftest test-activity
+  (with-app-with-config tk-app [remote-activity-reporter] (:client configs)
+      (let [consumer-svc (tk-app/get-service tk-app :ActivityReportingService)
+            handler (wrap-test-handler-middleware
+                             (fn [req]
+                               (if (= "/activity-api/v2/events" (:uri req))
+                                 (let [parsed-body (json/parse-string (:body req) true)]
+                                   (is (or (= v2-bundle parsed-body) (= expected-v1-upgraded-bundle parsed-body)))
+                                   ;; provide a payload for testability.  Actual service doesn't guarantee providing return results
+                                   (http/json-200-resp {:success true :actual (:body req)}))
+                                 (is false))))
+            v1-handler (wrap-test-handler-middleware
+                        (fn [req]
+                          (case (:uri req)
+                            "/activity-api/v2/events" (http/json-resp 404 {:success false})
+                            "/activity-api/v1/events" (http/json-200-resp {:success true :actual (:body req)}))))]
+
+        (testing "v2 endpoint supported with passthrough"
+          (with-test-webserver-and-config handler _ (:server configs)
+            (let [result (act/report-activity! consumer-svc v2-bundle)]
+              (is (= 200 (:status result)))
+              (is (= true (get-in result [:body :success])))
+              (is (= v2-bundle (json/parse-string (get-in result [:body :actual]) true))))))
+
+        (testing "upgrades to v2 payload when v1 payload is submitted"
+          (with-test-webserver-and-config handler _ (:server configs)
+                                          (let [result (act/report-activity! consumer-svc v1-bundle)]
+                                            (is (= 200 (:status result)))
+                                            (is (= true (get-in result [:body :success])))
+                                            (is (= expected-v1-upgraded-bundle (json/parse-string (get-in result [:body :actual]) true))))))
+
+        ;; note that after this test is done, if any more tests are added,
+        ;; the client will have stored that the v2 endpoint isn't available internally, and
+        ;; will use the v1 endpoint.  If this is undesirable, a new "with-app-with-config" should be created.
+        (testing "downgrades to v1 endpoint when v2 is a 404"
+          (with-test-webserver-and-config v1-handler _ (:server configs)
+            (let [result (act/report-activity! consumer-svc v2-bundle)]
+              (is (= 200 (:status result)))
+              (is (= true (get-in result [:body :success])))
+              (is (= expected-v1-bundle (json/parse-string (get-in result [:body :actual]) true)))))))))

--- a/test/puppetlabs/rbac_client/testutils/config.clj
+++ b/test/puppetlabs/rbac_client/testutils/config.clj
@@ -42,5 +42,6 @@
   [jetty-ssl-config]
   (let [{:keys [ssl-host ssl-port]} jetty-ssl-config]
     {:rbac-consumer {:api-url (format "https://%s:%s/rbac-api" ssl-host ssl-port)}
+     :activity-consumer {:api-url (format "https://%s:%s/activity-api" ssl-host ssl-port)}
      :global {:certs client-ssl-config
               :logging-config "dev-resources/logback-test.xml"}}))

--- a/test/puppetlabs/rbac_client/testutils/http.clj
+++ b/test/puppetlabs/rbac_client/testutils/http.clj
@@ -68,16 +68,21 @@
                              :rbac-url api-url}}))
         (handler req)))))
 
+(defn wrap-test-handler-mw
+  [handler]
+  (-> handler
+      wrap-params
+      wrap-check-json
+      wrap-read-body))
+
 (defn wrap-test-handler-middleware
   "Given a handler and the TK config map for the consumer service, wrap the
   handler with test middlewares that assert the handler is being given
   well-formed JSON requests to the same server as specified in the config."
   [handler config]
   (-> handler
-    wrap-params
-    wrap-check-json
-    wrap-read-body
-    (wrap-check-base-url config) ))
+      wrap-test-handler-mw
+      (wrap-check-base-url config)))
 
 (defn json-resp
   "Construct a ring response map with the given status code that has an


### PR DESCRIPTION
This adds support for the upcoming v2 endpoint for the activity service
that allows multiple objects and an ip-address to be included in
the activity service submission.

It updates the changelog, updates the version number to 1.0 and
adds some simple endpoint testing for the client code.

The service initially attempts to post to the v2 endpoint.  If that
results in a 404, the service caches that knowledge and resubmits
to the v1 endpoint.  Subsequent requests will use the v1 endpoint
exclusively.