### PR TITLE
(PE-29996) deprecate cert-whitelisted?, use rbac v2 endpoint, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.1.0
+  * deprecate cert-whitelisted?
+  * convert client to use RBAC v2/certs endpoint in favor of v1.  Falls back to v1 if v2 isn't available
+  * use clj-parent 4.6.3
+  
 ### 1.0.0
   * update to use clj-parent 2.6.0
   * add support for activity v2 api and fall back to v1 if v2 isn't supported

--- a/project.clj
+++ b/project.clj
@@ -5,12 +5,12 @@
    :password :env/clojars_jenkins_password
    :sign-releases false})
 
-(defproject puppetlabs/rbac-client "1.0.1-SNAPSHOT"
+(defproject puppetlabs/rbac-client "1.1.0-SNAPSHOT"
   :description "Tools for interacting with PE RBAC"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.6.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.3"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]
@@ -28,11 +28,12 @@
                                   [puppetlabs/trapperkeeper :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
+                                  [org.bouncycastle/bcpkix-jdk15on]
                                   ; transitive dependency
                                   [org.clojure/tools.nrepl "0.2.13"]]}
              :testutils {:source-paths ^:replace  ["test"]}}
 
-  :plugins [[lein-parent "0.3.1"]
+  :plugins [[lein-parent "0.3.7"]
             [puppetlabs/i18n "0.8.0"]]
 
   :classifiers  [["test" :testutils]]

--- a/src/puppetlabs/rbac_client/protocols/rbac.clj
+++ b/src/puppetlabs/rbac_client/protocols/rbac.clj
@@ -11,6 +11,10 @@
     responses.")
 
   (cert-whitelisted? [this ssl-client-cn]
+    "DEPRECATED: use cert-allowed? instead. Given an SSL client CN string, returns whether or not that CN is on RBAC's
+    certificate whitelist.")
+
+  (cert-allowed? [this ssl-client-cn]
     "Given an SSL client CN string, returns whether or not that CN is on RBAC's
     certificate whitelist.")
 
@@ -37,7 +41,7 @@
   (list-permitted [this token object-type action]
     "Returns the list of instances that correspond to the users permissions for
     a given `object-type` and `action` pair. ")
-    
+
   (list-permitted-for [this subject object-type action]
     "Returns the list of instances that correspond to the the user associated with
     the provided subject, for the given `object_type` and `action` pair.")

--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -1,10 +1,11 @@
 (ns puppetlabs.rbac-client.services.rbac
   (:require
    [clojure.string]
+   [clojure.tools.logging :as log]
    [puppetlabs.i18n.core :as i18n]
    [puppetlabs.http.client.common :as http]
    [puppetlabs.http.client.sync :refer [create-client]]
-   [puppetlabs.rbac-client.core :refer [json-api-caller]]
+   [puppetlabs.rbac-client.core :refer [json-api-caller http-error?, parse-body]]
    [puppetlabs.rbac-client.protocols.rbac :refer [RbacConsumerService]]
    [puppetlabs.trapperkeeper.core :refer [defservice]]
    [puppetlabs.trapperkeeper.services :refer [service-context]]
@@ -56,7 +57,8 @@
   "Wrap the json caller adding :throw-body to opts"
   ([client rbac-url method path] (rbac-client client rbac-url method path {}))
   ([client rbac-url method path opts]
-   (json-api-caller client rbac-url method path (assoc opts :throw-body true))))
+   ;; use merge to allow caller to override "throw-body"
+   (json-api-caller client rbac-url method path (merge {:throw-body true} opts))))
 
 (defn api-url->status-url
   "Given an RBAC api-url, convert that to the related status URL"
@@ -69,26 +71,56 @@
            (str ":" (.getPort api-url)))
          "/status/v1/services")))
 
+(defn request-certs-output
+  ([prefix client ssl-client-cn]
+   (request-certs-output prefix client ssl-client-cn true))
+  ([prefix client ssl-client-cn throw-error?]
+   (let [url (format "/%s/certs/%s" prefix ssl-client-cn)]
+     (-> (client :get url {:throw-body throw-error?})))))
+
+(defn cert-allowed?
+  [context ssl-client-cn]
+  (when ssl-client-cn
+    (let [v1-certs? (deref (:v1-certs? context))
+          try-v2? (or (nil? v1-certs?) (false? v1-certs?))
+          {:keys [rbac-client]} context]
+      (if try-v2?
+        ;; don't throw on failures to allow us to detect the 404
+        (let [v2-response (request-certs-output "v2" rbac-client ssl-client-cn false)
+              status (:status v2-response)]
+          (if (= 404 status)
+            (do
+              (swap! (:v1-certs? context) (constantly true))
+              (get-in (request-certs-output "v1" rbac-client ssl-client-cn)
+                      [:body :whitelisted]))
+            ;; if we got an error, make sure we handle it the way the rbac-client does
+            (if (http-error? v2-response)
+              (throw+ (update-in (parse-body v2-response) [:kind] keyword))
+              (get-in v2-response [:body :allowlisted]))))
+        (get-in (request-certs-output "v1" rbac-client ssl-client-cn)
+                [:body :whitelisted])))))
+
 (defservice remote-rbac-consumer-service
   RbacConsumerService
   [[:ConfigService get-in-config]]
 
   (init [_ tk-ctx]
-        (if-let [rbac-url (get-in-config [:rbac-consumer :api-url])]
-          (let [ssl-config (get-in-config [:global :certs])
-                route-limit {:max-connections-per-route 20}
-                certified-client (create-client (merge route-limit ssl-config))
-                uncertified-client (create-client (merge route-limit (select-keys ssl-config [:ssl-ca-cert])))]
-            (assoc tk-ctx
-                   :client certified-client
-                   :uncertified-client uncertified-client
-                   :rbac-client (partial rbac-client certified-client rbac-url)
-                   :uncertified-rbac-client (partial rbac-client uncertified-client rbac-url)
-                   :status-client (partial rbac-client certified-client (api-url->status-url rbac-url))))
-          (throw+ {:kind :puppetlabs.rbac-client/invalid-configuration
-                   :message (i18n/tru "''rbac-consumer'' not configured with an ''api-url''")})))
+    (if-let [rbac-url (get-in-config [:rbac-consumer :api-url])]
+      (let [ssl-config (get-in-config [:global :certs])
+            route-limit {:max-connections-per-route 20}
+            certified-client (create-client (merge route-limit ssl-config))
+            uncertified-client (create-client (merge route-limit (select-keys ssl-config [:ssl-ca-cert])))]
+        (assoc tk-ctx
+               :client certified-client
+               :uncertified-client uncertified-client
+               :rbac-client (partial rbac-client certified-client rbac-url)
+               :uncertified-rbac-client (partial rbac-client uncertified-client rbac-url)
+               :status-client (partial rbac-client certified-client (api-url->status-url rbac-url))
+               :v1-certs? (atom nil)))
+      (throw+ {:kind :puppetlabs.rbac-client/invalid-configuration
+               :message (i18n/tru "''rbac-consumer'' not configured with an ''api-url''")})))
 
-  (stop [this tk-ctx]
+  (stop [_ tk-ctx]
     (when-let [client (:client tk-ctx)]
       (http/close client))
     (when-let [client (:uncertified-client tk-ctx)]
@@ -96,66 +128,78 @@
     (dissoc tk-ctx :client :uncertified-client))
 
   (is-permitted? [this subject perm-str]
-                 (let [{:keys [rbac-client]} (service-context this)
-                       body {:token (str (:id subject))
-                             :permissions [(perm-str->map perm-str)]}]
-                   (-> (rbac-client :post "/v1/permitted" {:body body})
-                       :body
-                       first)))
+    (let [{:keys [rbac-client]} (service-context this)
+          body {:token (str (:id subject))
+                :permissions [(perm-str->map perm-str)]}]
+      (-> (rbac-client :post "/v1/permitted" {:body body})
+          :body
+          first)))
 
   (are-permitted? [this subject perm-strs]
-                  (let [{:keys [rbac-client]} (service-context this)
-                        body {:token (str (:id subject))
-                              :permissions (map perm-str->map perm-strs)}]
-                    (-> (rbac-client :post "/v1/permitted" {:body body})
-                        :body)))
+    (let [{:keys [rbac-client]} (service-context this)
+          body {:token (str (:id subject))
+                :permissions (map perm-str->map perm-strs)}]
+      (-> (rbac-client :post "/v1/permitted" {:body body})
+          :body)))
 
   (cert-whitelisted? [this ssl-client-cn]
-                     (when ssl-client-cn
-                       (let [{:keys [rbac-client]} (service-context this)
-                             url (str "/v1/certs/" ssl-client-cn)]
-                         (-> (rbac-client :get url)
-                             :body
-                             :whitelisted))))
+    (log/warn (i18n/trs "DEPRECATION: the 'cert-whitelisted?' function has been deprecated and will be removed in future versions. Use `cert-allowed?` instead."))
+    (cert-allowed? (service-context this) ssl-client-cn))
+
+  (cert-allowed? [this ssl-client-cn]
+    (cert-allowed? (service-context this) ssl-client-cn))
 
   (cert->subject [this ssl-client-cn]
-                 (when ssl-client-cn
-                   (let [{:keys [rbac-client]} (service-context this)
-                         url (str "/v1/certs/" ssl-client-cn)]
-                     (-> (rbac-client :get url)
-                         :body
-                         :subject
-                         (parse-subject)))))
+    (when ssl-client-cn
+      (let [context (service-context this)
+            v1-certs? (deref (:v1-certs? context))
+            try-v2? (or (nil? v1-certs?) (false? v1-certs?))
+            {:keys [rbac-client]} context]
+        (if try-v2?
+          ;; don't throw on errors so we can detect the 404
+          (let [v2-response (request-certs-output "v2" rbac-client ssl-client-cn false)
+                status (:status v2-response)]
+            (if (= 404 status)
+              (do
+                (swap! (:v1-certs? context) (constantly true))
+                (-> (request-certs-output "v1" rbac-client ssl-client-cn)
+                    (get-in [:body :subject])
+                    parse-subject))
+              (if (http-error? v2-response)
+                (throw+ (update-in (parse-body v2-response) [:kind] keyword))
+                (parse-subject (get-in v2-response [:body :subject])))))
+          (parse-subject (get-in (request-certs-output "v1" rbac-client ssl-client-cn)
+                               [:body :subject]))))))
 
   (valid-token->subject [this token-str]
-                        (let [{:keys [rbac-client]} (service-context this)
-                              [with-suffix? actual-token _] (re-matches #"(.*)\|no_keepalive" token-str)
-                              payload {:token (if with-suffix? actual-token token-str)
-                                       :update_last_activity? (not with-suffix?)}]
-                          (-> (rbac-client :post "/v2/auth/token/authenticate" {:body payload})
-                              :body
-                              (parse-subject))))
+    (let [{:keys [rbac-client]} (service-context this)
+          [with-suffix? actual-token _] (re-matches #"(.*)\|no_keepalive" token-str)
+          payload {:token (if with-suffix? actual-token token-str)
+                   :update_last_activity? (not with-suffix?)}]
+      (-> (rbac-client :post "/v2/auth/token/authenticate" {:body payload})
+          :body
+          (parse-subject))))
 
   (status [this level]
-          (let [{:keys [status-client]} (service-context this)]
-            (-> (status-client :get "" {:query-params {"level" (name level)}})
-                (get-in [:body :rbac-service])
-                (update :state keyword))))
+    (let [{:keys [status-client]} (service-context this)]
+      (-> (status-client :get "" {:query-params {"level" (name level)}})
+          (get-in [:body :rbac-service])
+          (update :state keyword))))
 
   (list-permitted [this token object-type action]
-                  (let [{:keys [uncertified-rbac-client]} (service-context this)
-                        headers {:headers {authn-header token}}]
-                    (-> (uncertified-rbac-client :get (str "/v1/permitted/" object-type "/" action) headers)
-                        :body)))
+    (let [{:keys [uncertified-rbac-client]} (service-context this)
+          headers {:headers {authn-header token}}]
+      (-> (uncertified-rbac-client :get (str "/v1/permitted/" object-type "/" action) headers)
+          :body)))
 
   (list-permitted-for [this subject object-type action]
-                      (let [{:keys [rbac-client]} (service-context this)
-                            user-id (str (:id subject))]
-                        (-> (rbac-client :get (str "/v1/permitted/" object-type "/" action "/" user-id))
-                            :body)))
+    (let [{:keys [rbac-client]} (service-context this)
+          user-id (str (:id subject))]
+      (-> (rbac-client :get (str "/v1/permitted/" object-type "/" action "/" user-id))
+          :body)))
 
   (subject [this user-id]
-           (let [{:keys [rbac-client]} (service-context this)]
-             (-> (rbac-client :get (str "/v1/users/" user-id))
-                 :body
-                 parse-subject))))
+    (let [{:keys [rbac-client]} (service-context this)]
+      (-> (rbac-client :get (str "/v1/users/" user-id))
+          :body
+          parse-subject))))

--- a/test/puppetlabs/rbac_client/middleware/test_authentication.clj
+++ b/test/puppetlabs/rbac_client/middleware/test_authentication.clj
@@ -65,7 +65,7 @@
   (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
     (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)]
       (testing "when everything goes well, the subject map is added to the request object"
-        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted true :subject rand-subject}))]
+        (let [rbac-handler (constantly (http/json-200-resp {:allowlisted true :subject rand-subject}))]
           (with-test-webserver-and-config rbac-handler _ (:server configs)
             (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
               (let [authd-handler (->> (fn [req] (http/json-200-resp (:subject req)))
@@ -76,7 +76,7 @@
                        (json/parse-string (:body resp) true))))))))
 
       (testing "the middleware blocks requests with an authorized token from a non-whitelisted cert"
-        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted false :subject nil}))]
+        (let [rbac-handler (constantly (http/json-200-resp {:allowlisted false :subject nil}))]
           (with-test-webserver-and-config rbac-handler _ (:server configs)
             (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
               (let [authd-handler (->> (fn [req] (is (= rand-subject (:subject req))))
@@ -85,7 +85,7 @@
                 (is (= 401 (:status resp))))))))
 
       (testing "the middleware blocks requests that have a non-whitelisted cert"
-        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted false :subject nil}))]
+        (let [rbac-handler (constantly (http/json-200-resp {:allowlisted false :subject nil}))]
           (with-test-webserver-and-config rbac-handler _ (:server configs)
             (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
               (let [authd-handler (->> (fn [req] (is (true? "middleware blocked request")))
@@ -97,7 +97,7 @@
   (with-app-with-config tk-app [remote-rbac-consumer-service] (:client configs)
     (let [consumer-svc (tk-app/get-service tk-app :RbacConsumerService)]
       (testing "when everything goes well, the subject map is added to the request object"
-        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted true :subject rand-subject}))]
+        (let [rbac-handler (constantly (http/json-200-resp {:allowlisted true :subject rand-subject}))]
           (with-test-webserver-and-config rbac-handler _ (:server configs)
             (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
               (let [authd-handler (->> (fn [req] (http/json-200-resp (:subject req)))
@@ -111,11 +111,11 @@
         (let [rbac-handler (constantly (http/json-200-resp rand-subject))]
           (with-test-webserver-and-config rbac-handler _ (:server configs)
             (let [authd-handler (->> (fn [req] (is (= rand-subject (:subject req))))
-                                      (middleware/wrap-token-and-cert-access consumer-svc))]
+                                     (middleware/wrap-token-and-cert-access consumer-svc))]
               (authd-handler request-with-token)))))
 
       (testing "the middleware blocks requests that have a non-whitelisted cert"
-        (let [rbac-handler (constantly (http/json-200-resp {:whitelisted false :subject nil}))]
+        (let [rbac-handler (constantly (http/json-200-resp {:allowlisted false :subject nil}))]
           (with-test-webserver-and-config rbac-handler _ (:server configs)
             (with-redefs [ssl-utils/get-cn-from-x509-certificate (constantly "foo.example.com")]
               (let [authd-handler (->> (fn [req] (is (true? "middleware blocked request")))

--- a/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
+++ b/test/puppetlabs/rbac_client/testutils/dummy_rbac_service.clj
@@ -34,6 +34,7 @@
   (are-permitted? [this subject perm-strs]
                   (vec (repeat (count perm-strs) true)))
   (cert-whitelisted? [this ssl-client-cn] true)
+  (cert-allowed? [this ssl-client-cn] true)
   (cert->subject [this ssl-client-cn]
     {:id #uuid "af94921f-bd76-4b58-b5ce-e17c029a2790"
      :login "api_user"})


### PR DESCRIPTION
This deprecates the cert-whitelisted? function in the rbac remote consumer interface.
It also adds a new function to the protocol for the rbac-consumer `cert-allowed?`
which mirrors the behavior of the old function with some small differences.  First
the new "v2" endpoint in RBAC is attempted to be used to resolve the validity
of the certificate.  If the v2 endpoint results in a 404 response, that is cached
and the v1 endpoint is returned.  Future requests will use the v1 endpoint if the
cached result shows that the v2 endpoint wasn't found.

The changelog was updated as well as the clj-parent version in preparation for release.