### PR TITLE
(PE-30059) fix event bundle issue

### DIFF
--- a/src/puppetlabs/rbac_client/services/activity.clj
+++ b/src/puppetlabs/rbac_client/services/activity.clj
@@ -11,19 +11,18 @@
 (defn v1->v2
   ;; make any adjustments needed to make a (maybe) v1 payload into a v2 payload
   [event-bundle]
-  (if (contains? event-bundle :object)
-    (-> event-bundle
-        (dissoc :object)
-        (assoc :objects [(:object event-bundle)]))
+  (if-let [object (get-in event-bundle [:commit :object])]
+    (-> (assoc-in event-bundle [:commit :objects] [object])
+        (update-in [:commit] dissoc :object))
     event-bundle))
 
 (defn v2->v1
   ;; make any adjustments needed to make a (maybe) v2 payload into a v1 payload
   [event-bundle]
-  (let [result (dissoc event-bundle :ip-address)]
-    (if (contains? event-bundle :objects)
-      (-> (dissoc result :objects)
-          (assoc :object (first (:objects event-bundle))))
+  (let [result (update-in event-bundle [:commit] dissoc :ip-address)]
+    (if-let [objects (get-in event-bundle [:commit :objects])]
+      (-> (assoc-in result [:commit :object] (first objects))
+          (update-in [:commit] dissoc :objects))
       result)))
 
 (defn report-activity

--- a/test/puppetlabs/rbac_client/services/test_activity.clj
+++ b/test/puppetlabs/rbac_client/services/test_activity.clj
@@ -19,60 +19,47 @@
   (http/wrap-test-handler-mw handler))
 
 (def v2-bundle
-  {:commit
-   {:service
-    {:id "namer"}}
-   :subject
-   {:name "Herman Melville"
-    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
-   :objects
-   [{:name "Herman Aldrich"
-     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
-     :type "a Herman"}
-    {:name "Herman Miller",
-     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac33",
-     :type "a Herman"}
-    {:name "Herman Stump",
-     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac34",
-     :type "a Herman"}
-    {:name "Herman W. Hellman",
-     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac35",
-     :type "a Herman"}]
-   :ip-address "an ip address"})
+  {:commit {:service {:id "namer"}
+            :subject {:name "Herman Melville"
+                      :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+            :objects 
+              [{:name "Herman Aldrich"
+                :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+                :type "a Herman"}
+               {:name "Herman Miller",
+                :id "2d5d4e0b-5353-4bbd-9c4c-084177caac33",
+                :type "a Herman"}
+               {:name "Herman Stump",
+                :id "2d5d4e0b-5353-4bbd-9c4c-084177caac34",
+                :type "a Herman"}
+               {:name "Herman W. Hellman",
+                :id "2d5d4e0b-5353-4bbd-9c4c-084177caac35",
+                :type "a Herman"}]
+            :ip-address "an ip address"}})
 
 (def v1-bundle
-  {:commit
-   {:service
-    {:id "namer"}}
-   :subject
-   {:name "Herman Melville"
-    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
-   :object {:name "Herman Aldrich"
-            :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
-            :type "a Herman"}})
+  {:commit {:service {:id "namer"}
+            :subject {:name "Herman Melville" 
+                      :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+            :object {:name "Herman Aldrich" 
+                     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32" 
+                     :type "a Herman"}}})
 
 (def expected-v1-bundle
-  {:commit
-   {:service
-    {:id "namer"}}
-   :subject
-   {:name "Herman Melville"
-    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
-   :object
-   {:name "Herman Aldrich"
-    :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
-    :type "a Herman"}})
+  {:commit {:service {:id "namer"}
+            :subject {:name "Herman Melville"
+                      :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+            :object {:name "Herman Aldrich"
+                     :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+                     :type "a Herman"}}})
 
 (def expected-v1-upgraded-bundle
-  {:commit
-   {:service
-    {:id "namer"}}
-   :subject
-   {:name "Herman Melville"
-    :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
-   :objects [{:name "Herman Aldrich"
-              :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
-              :type "a Herman"}]})
+  {:commit {:service {:id "namer"}
+            :subject {:name "Herman Melville"
+                      :id "42bf351c-f9ec-40af-84ad-e976fec7f4bd"}
+            :objects [{:name "Herman Aldrich"
+                       :id "2d5d4e0b-5353-4bbd-9c4c-084177caac32"
+                       :type "a Herman"}]}})
 
 
 (deftest test-activity


### PR DESCRIPTION
This updates the way v1 and v2 event bundles are handled within activity reporting so that the expected subject and object information is accessed and stored within the top-level "commit" key.  Previously we were interacting with them as top-level keys themselves.  Test fixtures are updated accordingly.