### PR TITLE
(PE-31016) Bump clj-parent to 4.6.17

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.14"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.17"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
The update includes some security fixes in the commons-compress dependency.

Signed-off-by: Enis Inan <enis.inan@puppet.com>