### PR TITLE
(maint) Update str->uuid function to allow parsing UUIDs

### DIFF
--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -26,13 +26,12 @@
      :instance instance}))
 
 (defn str->uuid
-  "COPY-PASTE: https://github.com/puppetlabs/pe-rbac-service/blob/master/src/clj/puppetlabs/rbac/utils.clj"
+  "Convert a string into a UUID. If the ojbect is already a UUID return it"
   [str-uuid]
   (try
-    (UUID/fromString str-uuid)
-    (catch IllegalArgumentException e
+    (if (uuid? str-uuid) str-uuid (UUID/fromString str-uuid))
+    (catch IllegalArgumentException _
       (throw+ {:uuid str-uuid
-               ;; DOCS REVIEWED
                :msg (i18n/tru "Error parsing UUID {0}" str-uuid)
                :kind ::invalid-uuid}))))
 

--- a/test/puppetlabs/rbac_client/services/test_rbac.clj
+++ b/test/puppetlabs/rbac_client/services/test_rbac.clj
@@ -3,7 +3,7 @@
             [puppetlabs.http.client.sync :refer [create-client]]
             [puppetlabs.kitchensink.json :as json]
             [puppetlabs.rbac-client.protocols.rbac :as rbac]
-            [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service api-url->status-url perm-str->map]]
+            [puppetlabs.rbac-client.services.rbac :refer [remote-rbac-consumer-service api-url->status-url perm-str->map parse-subject]]
             [puppetlabs.rbac-client.testutils.config :as cfg]
             [puppetlabs.rbac-client.testutils.http :as http]
             [puppetlabs.trapperkeeper.logging :refer [reset-logging]]
@@ -325,3 +325,9 @@
                 :status {:db_up false,
                          :activity_up true}}
                (rbac/status consumer-svc "critical")))))))
+
+(deftest parse-subject-test
+  (testing "parses subject with string id"
+    (is (uuid? (:id (parse-subject (assoc rand-subject :id (.toString (UUID/randomUUID)))))))))
+  (testing "parses subject with UUID id"
+    (is (uuid? (:id (parse-subject rand-subject)))))


### PR DESCRIPTION
The str-uuid function is used in the parse-subject function to ensure subject ids are proper UUID objects. If an id is already a UUID instead of raising an exception it is helpful to just return that UUID instead of rasing a `ClassCastException`. The use case for this change is to use `parse-subject` to normalize subjects when using the rbac client, for example replacing `->rbac-subject` in https://github.com/puppetlabs/orchestrator/blob/c4d3e0da65eab03e887b07fe8ed13407014a388e/src/puppetlabs/orchestrator/rbac.clj#L10-L19 where subjects may or may not already have their IDs in UUID form based on whether or not they have been serialized/deserialized from for example a DB query.