### PR TITLE
(PE-34395) Update RbacSubject schema to include identity-provider-id

### DIFF
--- a/src/puppetlabs/rbac_client/middleware/authentication.clj
+++ b/src/puppetlabs/rbac_client/middleware/authentication.clj
@@ -110,7 +110,8 @@
    (sc/optional-key :is_superuser) sc/Bool
    (sc/optional-key :is_revoked) sc/Bool
    (sc/optional-key :is_remote) sc/Bool
-   (sc/optional-key :is_group) sc/Bool})
+   (sc/optional-key :is_group) sc/Bool
+   (sc/optional-key :identity_provider_id) (sc/maybe java.util.UUID)})
 
 (defn- wrap-block-anonymous-access
   "This internal middleware blocks any request that doesn't have a key set for

--- a/src/puppetlabs/rbac_client/services/rbac.clj
+++ b/src/puppetlabs/rbac_client/services/rbac.clj
@@ -26,7 +26,7 @@
      :instance instance}))
 
 (defn str->uuid
-  "Convert a string into a UUID. If the ojbect is already a UUID return it"
+  "Convert a string into a UUID. If the object is already a UUID return it"
   [str-uuid]
   (try
     (if (uuid? str-uuid) str-uuid (UUID/fromString str-uuid))
@@ -41,15 +41,22 @@
     (assoc subject-map :group_ids (map str->uuid group-ids))
     subject-map))
 
+(defn identity-provider-id-str->uuid
+  [subject-map]
+  (if-let [identity-provider-id (:identity_provider_id subject-map)]
+    (assoc subject-map :identity_provider_id (str->uuid identity-provider-id))
+    subject-map))
+
 (defn parse-subject
   [subject]
-  (if subject
+  (when subject
     (-> subject
         (select-keys [:id :login :display_name :email
                       :last_login :role_ids :inherited_role_ids
                       :group_ids :is_superuser :is_revoked
-                      :is_remote :is_group])
+                      :is_remote :is_group :identity_provider_id])
         group-ids-str->uuids
+        identity-provider-id-str->uuid
         (update :id str->uuid))))
 
 (defn rbac-client


### PR DESCRIPTION
Adding this field in RBAC, schema update is necessary for integration tests to pass.