### PR TITLE
(maint) bump clj-parent to 5.2.11, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 1.1.4
+ * add optional identity provider id into RBAC subject
+ * update clj-parent to 5.2.11
+
+### 1.1.3 
+ * update str->uuid function to allow UUIDs
+
+### 1.1.2
+ * update clj-parent 4.6.17
+
+### 1.1.1
+ * fix activity reporting event handling
+
 ### 1.1.0
   * deprecate cert-whitelisted?
   * convert client to use RBAC v2/certs endpoint in favor of v1.  Falls back to v1 if v2 isn't available

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.17"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.11"]
                    :inherit [:managed-dependencies]}
 
   :dependencies [[org.clojure/clojure]


### PR DESCRIPTION
This updates clj-parent to 5.2.11, and updates the changelog in preparation for a release.